### PR TITLE
feat: change instrumentation provider

### DIFF
--- a/connector/apmconnector/metric_connector_test.go
+++ b/connector/apmconnector/metric_connector_test.go
@@ -29,15 +29,15 @@ func TestConvertOneSpanToMetrics(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	config := Config{ApdexT: 0.5}
 	metrics := ConvertTraces(logger, &config, traces)
-	assert.Equal(t, 4, metrics.MetricCount())
+	assert.Equal(t, 5, metrics.MetricCount())
 	rm := metrics.ResourceMetrics().At(0)
 	serviceName, _ := rm.Resource().Attributes().Get("service.name")
 	assert.Equal(t, "service", serviceName.AsString())
 	sm := rm.ScopeMetrics().At(0)
 	metric := sm.Metrics().At(0)
-	assert.Equal(t, "apm.service.transaction.duration", metric.Name())
-	dp := metric.Histogram().DataPoints().At(0)
-	assert.Equal(t, 1.0, dp.Sum())
+	assert.Equal(t, "apm.service.apdex", metric.Name())
+	dp := metric.Sum().DataPoints().At(0)
+	assert.Equal(t, 0.0, dp.DoubleValue())
 }
 
 func addSpan(spanSlice ptrace.SpanSlice, attributes map[string]string, spanValues []TestSpan) {

--- a/connector/apmconnector/transaction.go
+++ b/connector/apmconnector/transaction.go
@@ -239,13 +239,6 @@ func (transaction *Transaction) ProcessRootSpan() bool {
 		transaction.IncrementErrorCount(transactionName, transactionType, span.EndTimestamp())
 	}
 
-	{
-		attributes := pcommon.NewMap()
-		attributes.PutStr("transactionType", transactionType.AsString())
-		attributes.PutStr("transactionName", transactionName)
-
-		transaction.resourceMetrics.RecordHistogramFromSpan("apm.service.transaction.duration", attributes, span)
-	}
 	transaction.GenerateApdexMetrics(span, err, transactionName, transactionType)
 
 	breakdownBySegment := make(map[string]int64)
@@ -271,6 +264,22 @@ func (transaction *Transaction) ProcessRootSpan() bool {
 		transaction.resourceMetrics.RecordHistogram(overviewMetricName, attributes,
 			span.StartTimestamp(), span.EndTimestamp(), sum)
 	}
+
+	{
+		attributes := pcommon.NewMap()
+		attributes.PutStr("transactionType", transactionType.AsString())
+		attributes.PutStr("transactionName", transactionName)
+		attributes.PutStr("metricTimesliceName", transactionName)
+
+		transaction.resourceMetrics.RecordHistogramFromSpan("apm.service.transaction.duration", attributes, span)
+
+		attributes.PutStr("transactionName", transactionName)
+
+		// blame any time not attributed to measurements to the transaction itself
+		transaction.resourceMetrics.RecordHistogram("apm.service.transaction.overview", attributes,
+			span.StartTimestamp(), span.EndTimestamp(), remainingNanos)
+	}
+
 	return true
 }
 

--- a/processor/apmprocessor/common.go
+++ b/processor/apmprocessor/common.go
@@ -1,0 +1,24 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apmprocessor // import "github.com/newrelic/opentelemetry-collector-components/processor/apmprocessor"
+
+import "go.opentelemetry.io/collector/pdata/pcommon"
+
+func setInstrumentationProvider(config Config, resource pcommon.Resource) {
+	if !config.ChangeInstrumentationProvider {
+		return
+	}
+	instrumentationProvider, instrumentationProviderPresent := resource.Attributes().Get("instrumentation.provider")
+	if instrumentationProviderPresent {
+		if instrumentationProvider.AsString() == "opentelemetry" {
+			resource.Attributes().PutStr("instrumentation.provider", "newrelic-opentelemetry")
+		}
+		return
+	}
+
+	sdk, sdkPresent := resource.Attributes().Get("telemetry.sdk.name")
+	if sdkPresent && sdk.AsString() == "opentelemetry" {
+		resource.Attributes().PutStr("instrumentation.provider", "newrelic-opentelemetry")
+	}
+}

--- a/processor/apmprocessor/config.go
+++ b/processor/apmprocessor/config.go
@@ -8,6 +8,8 @@ import (
 )
 
 type Config struct {
+	// If set to true, will set the `instrumentation.provider` attribute to `newrelic-opentelemetry`
+	ChangeInstrumentationProvider bool `mapstructure:"changeInstrumentationProvider"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/processor/apmprocessor/factory.go
+++ b/processor/apmprocessor/factory.go
@@ -16,8 +16,10 @@ var processorCapabilities = consumer.Capabilities{MutatesData: true}
 
 // FIXME copying this from the metadata/generated_status to be able to build the component externally
 const (
-	Type            = "newrelicapm"
-	TracesStability = component.StabilityLevelDevelopment
+	Type             = "newrelicapm"
+	TracesStability  = component.StabilityLevelDevelopment
+	MetricsStability = component.StabilityLevelDevelopment
+	LogsStability    = component.StabilityLevelDevelopment
 )
 
 // NewFactory returns a new factory for the Attributes processor.
@@ -26,11 +28,13 @@ func NewFactory() processor.Factory {
 		Type,
 		createDefaultConfig,
 		processor.WithTraces(createTracesProcessor, TracesStability),
+		processor.WithMetrics(createMetricsProcessor, MetricsStability),
+		processor.WithLogs(createLogsProcessor, LogsStability),
 	)
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{}
+	return &Config{ChangeInstrumentationProvider: true}
 }
 
 func createTracesProcessor(
@@ -50,5 +54,43 @@ func createTracesProcessor(
 		cfg,
 		nextConsumer,
 		sp.processTraces,
+		processorhelper.WithCapabilities(processorCapabilities))
+}
+
+func createMetricsProcessor(
+	ctx context.Context,
+	set processor.CreateSettings,
+	cfg component.Config,
+	nextConsumer consumer.Metrics,
+) (processor.Metrics, error) {
+	oCfg := cfg.(*Config)
+
+	metricsProcessor := newMetricProcessor(*oCfg, set.Logger)
+
+	return processorhelper.NewMetricsProcessor(
+		ctx,
+		set,
+		cfg,
+		nextConsumer,
+		metricsProcessor.processMetrics,
+		processorhelper.WithCapabilities(processorCapabilities))
+}
+
+func createLogsProcessor(
+	ctx context.Context,
+	set processor.CreateSettings,
+	cfg component.Config,
+	nextConsumer consumer.Logs,
+) (processor.Logs, error) {
+	oCfg := cfg.(*Config)
+
+	logProcessor := newLogProcessor(*oCfg, set.Logger)
+
+	return processorhelper.NewLogsProcessor(
+		ctx,
+		set,
+		cfg,
+		nextConsumer,
+		logProcessor.processLogs,
 		processorhelper.WithCapabilities(processorCapabilities))
 }

--- a/processor/apmprocessor/internal/metadata/generated_status.go
+++ b/processor/apmprocessor/internal/metadata/generated_status.go
@@ -7,6 +7,8 @@ import (
 )
 
 const (
-	Type            = "newrelicapm"
-	TracesStability = component.StabilityLevelDevelopment
+	Type             = "newrelicapm"
+	LogsStability    = component.StabilityLevelDevelopment
+	MetricsStability = component.StabilityLevelDevelopment
+	TracesStability  = component.StabilityLevelDevelopment
 )

--- a/processor/apmprocessor/log.go
+++ b/processor/apmprocessor/log.go
@@ -1,0 +1,28 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apmprocessor // import "github.com/newrelic/opentelemetry-collector-components/processor/apmprocessor"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+)
+
+type logProcessor struct {
+	logger *zap.Logger
+	config Config
+}
+
+func newLogProcessor(config Config, logger *zap.Logger) *logProcessor {
+	return &logProcessor{config: config, logger: logger}
+}
+
+func (lp *logProcessor) processLogs(_ context.Context, ld plog.Logs) (plog.Logs, error) {
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		rs := ld.ResourceLogs().At(i)
+		setInstrumentationProvider(lp.config, rs.Resource())
+	}
+	return ld, nil
+}

--- a/processor/apmprocessor/log_test.go
+++ b/processor/apmprocessor/log_test.go
@@ -1,0 +1,49 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apmprocessor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/processortest"
+)
+
+func TestProcessLog(t *testing.T) {
+	sink := new(consumertest.LogsSink)
+	lp, err := createTestLogsProcessor(sink)
+	require.Nil(t, err)
+	require.NotNil(t, lp)
+
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	resourceLogs.Resource().Attributes().PutStr("service.name", "service")
+	resourceLogs.Resource().Attributes().PutStr("telemetry.sdk.name", "opentelemetry")
+	logRecords := resourceLogs.ScopeLogs().AppendEmpty().LogRecords()
+	lr := logRecords.AppendEmpty()
+	lr.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+
+	err = lp.ConsumeLogs(context.Background(), logs)
+	require.Nil(t, err)
+	provider, providerPresent := sink.AllLogs()[0].ResourceLogs().At(0).Resource().Attributes().Get("instrumentation.provider")
+	assert.True(t, providerPresent)
+	assert.Equal(t, "newrelic-opentelemetry", provider.AsString())
+}
+
+func createTestLogsProcessor(sink consumer.Logs) (processor.Logs, error) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	oCfg := cfg.(*Config)
+	lp, err := factory.CreateLogsProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, sink)
+
+	return lp, err
+}

--- a/processor/apmprocessor/metadata.yaml
+++ b/processor/apmprocessor/metadata.yaml
@@ -3,6 +3,6 @@ type: newrelicapm
 status:
   class: processor
   stability:
-    development: [traces]
+    development: [logs, metrics, traces]
   codeowners:
     active: [jlegoff, sdaubin]

--- a/processor/apmprocessor/metric.go
+++ b/processor/apmprocessor/metric.go
@@ -1,0 +1,28 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apmprocessor // import "github.com/newrelic/opentelemetry-collector-components/processor/apmprocessor"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+type metricProcessor struct {
+	logger *zap.Logger
+	config Config
+}
+
+func newMetricProcessor(config Config, logger *zap.Logger) *metricProcessor {
+	return &metricProcessor{config: config, logger: logger}
+}
+
+func (mp *metricProcessor) processMetrics(_ context.Context, md pmetric.Metrics) (pmetric.Metrics, error) {
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rs := md.ResourceMetrics().At(i)
+		setInstrumentationProvider(mp.config, rs.Resource())
+	}
+	return md, nil
+}

--- a/processor/apmprocessor/metric_test.go
+++ b/processor/apmprocessor/metric_test.go
@@ -1,0 +1,53 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apmprocessor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/processortest"
+)
+
+func TestProcessMetric(t *testing.T) {
+	sink := new(consumertest.MetricsSink)
+	mp, err := createTestMetricsProcessor(sink)
+	require.Nil(t, err)
+	require.NotNil(t, mp)
+
+	metrics := pmetric.NewMetrics()
+	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+	resourceMetrics.Resource().Attributes().PutStr("service.name", "service")
+	resourceMetrics.Resource().Attributes().PutStr("telemetry.sdk.name", "opentelemetry")
+	scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
+	metric := scopeMetrics.Metrics().AppendEmpty()
+	metric.SetEmptySum()
+	dp := metric.Sum().DataPoints().AppendEmpty()
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	dp.SetIntValue(1)
+
+	err = mp.ConsumeMetrics(context.Background(), metrics)
+	require.Nil(t, err)
+
+	provider, providerPresent := sink.AllMetrics()[0].ResourceMetrics().At(0).Resource().Attributes().Get("instrumentation.provider")
+	assert.True(t, providerPresent)
+	assert.Equal(t, "newrelic-opentelemetry", provider.AsString())
+}
+
+func createTestMetricsProcessor(sink consumer.Metrics) (processor.Metrics, error) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	oCfg := cfg.(*Config)
+	mp, err := factory.CreateMetricsProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, sink)
+
+	return mp, err
+}

--- a/processor/apmprocessor/span.go
+++ b/processor/apmprocessor/span.go
@@ -13,10 +13,11 @@ import (
 type spanProcessor struct {
 	sqlparser *SQLParser
 	logger    *zap.Logger
+	config    Config
 }
 
-func newSpanProcessor(_ Config, logger *zap.Logger) (*spanProcessor, error) {
-	return &spanProcessor{sqlparser: NewSQLParser(), logger: logger}, nil
+func newSpanProcessor(config Config, logger *zap.Logger) (*spanProcessor, error) {
+	return &spanProcessor{config: config, sqlparser: NewSQLParser(), logger: logger}, nil
 }
 
 func (sp *spanProcessor) processTraces(_ context.Context, td ptrace.Traces) (ptrace.Traces, error) {
@@ -27,6 +28,8 @@ func (sp *spanProcessor) processTraces(_ context.Context, td ptrace.Traces) (ptr
 			sp.logger.Debug("Skipping resource spans", zap.String("instrumentation.provider", instrumentationProvider.AsString()))
 			continue
 		}
+
+		setInstrumentationProvider(sp.config, rs.Resource())
 
 		for j := 0; j < rs.ScopeSpans().Len(); j++ {
 			scopeSpan := rs.ScopeSpans().At(j)


### PR DESCRIPTION
This PR does two things:

1. add a blame metric for the remaining time (previously created as part of this other [PR](https://github.com/newrelic/opentelemetry-collector-components/pull/144))
2. change the `instrumentation.provider` resource attribute to `newrelic-opentelemetry` in order for our UI to be displayed properly