### PR TITLE
fix: Compute transaction key to prevent cross service contamination

### DIFF
--- a/connector/apmconnector/metric_connector.go
+++ b/connector/apmconnector/metric_connector.go
@@ -74,7 +74,7 @@ func ConvertTraces(logger *zap.Logger, config *Config, td ptrace.Traces) pmetric
 					}
 				}
 
-				transaction, _ := transactions.GetOrCreateTransaction(sdkLanguage, span, resourceMetrics)
+				transaction, _ := transactions.GetOrCreateTransaction(sdkLanguage, span, resourceMetrics, rs.Resource().Attributes())
 
 				transaction.AddSpan(span)
 			}

--- a/connector/apmconnector/transaction.go
+++ b/connector/apmconnector/transaction.go
@@ -103,6 +103,7 @@ func GetTransactionKey(traceID string, resourceAttributes pcommon.Map) string {
 			values = append(values, "")
 		}
 	}
+	values = append(values, traceID)
 	return strings.Join(values[:], ":")
 }
 

--- a/connector/apmconnector/transaction_test.go
+++ b/connector/apmconnector/transaction_test.go
@@ -66,13 +66,13 @@ func TestGetOrCreateTransaction(t *testing.T) {
 	span := ptrace.NewSpan()
 	meterProvider := NewMeterProvider()
 	metrics := meterProvider.getOrCreateResourceMetrics(pcommon.NewMap())
-	transaction, _ := transactions.GetOrCreateTransaction("java", span, metrics)
+	transaction, _ := transactions.GetOrCreateTransaction("java", span, metrics, pcommon.NewMap())
 
 	transaction.SetRootSpan(span)
 	assert.Equal(t, true, transaction.IsRootSet())
 	transactions.ProcessTransactions()
 
-	existingTransaction, _ := transactions.GetOrCreateTransaction("java", span, metrics)
+	existingTransaction, _ := transactions.GetOrCreateTransaction("java", span, metrics, pcommon.NewMap())
 	assert.Equal(t, transaction, existingTransaction)
 	assert.Equal(t, true, existingTransaction.IsRootSet())
 }

--- a/connector/apmconnector/transaction_test.go
+++ b/connector/apmconnector/transaction_test.go
@@ -65,16 +65,57 @@ func TestGetOrCreateTransaction(t *testing.T) {
 	transactions := NewTransactionsMap(0.5)
 	span := ptrace.NewSpan()
 	meterProvider := NewMeterProvider()
-	metrics := meterProvider.getOrCreateResourceMetrics(pcommon.NewMap())
-	transaction, _ := transactions.GetOrCreateTransaction("java", span, metrics, pcommon.NewMap())
+	resources := pcommon.NewMap()
+	metrics := meterProvider.getOrCreateResourceMetrics(resources)
+	transaction, _ := transactions.GetOrCreateTransaction("java", span, metrics, resources)
 
 	transaction.SetRootSpan(span)
 	assert.Equal(t, true, transaction.IsRootSet())
 	transactions.ProcessTransactions()
 
-	existingTransaction, _ := transactions.GetOrCreateTransaction("java", span, metrics, pcommon.NewMap())
-	assert.Equal(t, transaction, existingTransaction)
+	existingTransaction, _ := transactions.GetOrCreateTransaction("java", span, metrics, resources)
+	assert.Same(t, transaction, existingTransaction)
 	assert.Equal(t, true, existingTransaction.IsRootSet())
+}
+
+func TestGetOrCreateTransactionMultipleSpans(t *testing.T) {
+	transactions := NewTransactionsMap(0.5)
+	span := ptrace.NewSpan()
+	span.SetTraceID(pcommon.TraceID{0x01})
+	span.SetSpanID(pcommon.SpanID{0x01})
+	meterProvider := NewMeterProvider()
+	resources := pcommon.NewMap()
+	resources.PutStr("service.name", "authentication")
+	metrics := meterProvider.getOrCreateResourceMetrics(resources)
+	transaction, _ := transactions.GetOrCreateTransaction("java", span, metrics, resources)
+
+	span = ptrace.NewSpan()
+	span.SetTraceID(pcommon.TraceID{0x01})
+	span.SetSpanID(pcommon.SpanID{0x02})
+
+	existingTransaction, _ := transactions.GetOrCreateTransaction("java", span, metrics, resources)
+	assert.Same(t, transaction, existingTransaction)
+}
+
+func TestGetOrCreateTransactionMultipleServices(t *testing.T) {
+	transactions := NewTransactionsMap(0.5)
+	span := ptrace.NewSpan()
+	span.SetTraceID(pcommon.TraceID{0x01})
+	span.SetSpanID(pcommon.SpanID{0x01})
+	meterProvider := NewMeterProvider()
+	resources := pcommon.NewMap()
+	resources.PutStr("service.name", "authentication")
+	metrics := meterProvider.getOrCreateResourceMetrics(resources)
+	transaction, _ := transactions.GetOrCreateTransaction("java", span, metrics, resources)
+
+	span = ptrace.NewSpan()
+	span.SetTraceID(pcommon.TraceID{0x01})
+	span.SetSpanID(pcommon.SpanID{0x02})
+
+	resources.PutStr("service.name", "cart")
+
+	existingTransaction, _ := transactions.GetOrCreateTransaction("java", span, metrics, resources)
+	assert.NotSame(t, transaction, existingTransaction)
 }
 
 func TestGetTransactionMetricNameRpcService(t *testing.T) {


### PR DESCRIPTION
Right now we key transactions using the trace id.  When a trace spans multiple services, the collector might process data for multiple services together, and it ends up polluting transactions with data from multiple services.  This changes the code to key off of

    "host.name", "service.name", "container.id", "telemetry.sdk.language"