### PR TITLE
Refactor transaction name method for reuse with metrics

### DIFF
--- a/connector/apmconnector/transaction.go
+++ b/connector/apmconnector/transaction.go
@@ -375,45 +375,57 @@ func (measurement Measurement) ExclusiveTime(transaction *Transaction) int64 {
 
 func GetTransactionMetricName(span ptrace.Span) (string, TransactionType) {
 	if span.Kind() == ptrace.SpanKindConsumer || span.Kind() == ptrace.SpanKindProducer {
-		system, systemPresent := span.Attributes().Get("messaging.system")
-		if !systemPresent {
-			system = pcommon.NewValueStr("unknownSystem")
-		}
-
-		destinationName, destinationNamePresent := span.Attributes().Get("messaging.destination.name")
-		if !destinationNamePresent {
-			destinationName = pcommon.NewValueStr("unknown")
-		}
-		operation, operationPresent := span.Attributes().Get("messaging.operation")
-		if !operationPresent {
-			operation = pcommon.NewValueStr("unknown")
-		}
-
-		return fmt.Sprintf("OtherTransaction/%s/%s/%s/%s", span.Kind().String(), system.AsString(), destinationName.AsString(), operation.AsString()), OtherTransactionType
+		return GetConsumerOrProducerTransactionMetricName(span.Kind().String(), span.Attributes())
 	}
 	if span.Kind() != ptrace.SpanKindServer {
 		return "", NullTransactionType
 	}
-	if rpcService, rpcServicePresent := span.Attributes().Get("rpc.service"); rpcServicePresent {
-		if rpcMethod, rpcMethodPresent := span.Attributes().Get("rpc.method"); rpcMethodPresent {
+	name, txType := GetServerTransactionMetricName(span.Attributes())
+	if txType == NullTransactionType {
+		return fmt.Sprintf("WebTransaction/Other/%s", span.Name()), WebTransactionType
+	}
+	return name, txType
+}
+
+func GetConsumerOrProducerTransactionMetricName(kind string, attributes pcommon.Map) (string, TransactionType) {
+	system, systemPresent := attributes.Get("messaging.system")
+	if !systemPresent {
+		system = pcommon.NewValueStr("unknownSystem")
+	}
+
+	destinationName, destinationNamePresent := attributes.Get("messaging.destination.name")
+	if !destinationNamePresent {
+		destinationName = pcommon.NewValueStr("unknown")
+	}
+	operation, operationPresent := attributes.Get("messaging.operation")
+	if !operationPresent {
+		operation = pcommon.NewValueStr("unknown")
+	}
+
+	return fmt.Sprintf("OtherTransaction/%s/%s/%s/%s", kind, system.AsString(), destinationName.AsString(), operation.AsString()), OtherTransactionType
+}
+
+func GetServerTransactionMetricName(attributes pcommon.Map) (string, TransactionType) {
+	if rpcService, rpcServicePresent := attributes.Get("rpc.service"); rpcServicePresent {
+		if rpcMethod, rpcMethodPresent := attributes.Get("rpc.method"); rpcMethodPresent {
 			return fmt.Sprintf("WebTransaction/rpc/%s/%s", rpcService.AsString(), rpcMethod.AsString()), WebTransactionType
 		}
 		return fmt.Sprintf("WebTransaction/rpc/%s", rpcService.AsString()), WebTransactionType
 	}
-	if httpRoute, routePresent := span.Attributes().Get("http.route"); routePresent {
-		return GetWebTransactionMetricName(span, httpRoute.Str(), "http.route")
+	if httpRoute, routePresent := attributes.Get("http.route"); routePresent {
+		return GetWebTransactionMetricName(attributes, httpRoute.Str(), "http.route")
 	}
-	if urlPath, _ := GetFirst(span.Attributes(), []string{"url.path", "http.target"}); urlPath.Type() != pcommon.ValueTypeEmpty {
-		return GetWebTransactionMetricName(span, urlPath.Str(), "Uri")
+	if urlPath, _ := GetFirst(attributes, []string{"url.path", "http.target"}); urlPath.Type() != pcommon.ValueTypeEmpty {
+		return GetWebTransactionMetricName(attributes, urlPath.Str(), "Uri")
 	}
-	if method, methodPresent := span.Attributes().Get("http.method"); methodPresent {
+	if method, methodPresent := attributes.Get("http.method"); methodPresent {
 		return fmt.Sprintf("WebTransaction/http.method/%s", method.Str()), WebTransactionType
 	}
-	return fmt.Sprintf("WebTransaction/Other/%s", span.Name()), WebTransactionType
+	return "", NullTransactionType
 }
 
-func GetWebTransactionMetricName(span ptrace.Span, name, nameType string) (string, TransactionType) {
-	if method, methodPresent := span.Attributes().Get("http.method"); methodPresent {
+func GetWebTransactionMetricName(attributes pcommon.Map, name, nameType string) (string, TransactionType) {
+	if method, methodPresent := attributes.Get("http.method"); methodPresent {
 		return fmt.Sprintf("WebTransaction/%s%s (%s)", nameType, name, method.Str()), WebTransactionType
 	}
 	return fmt.Sprintf("WebTransaction/%s%s", nameType, name), WebTransactionType

--- a/connector/apmconnector/transaction.go
+++ b/connector/apmconnector/transaction.go
@@ -417,13 +417,13 @@ func GetServerTransactionMetricName(attributes pcommon.Map) (string, Transaction
 		return GetWebTransactionMetricName(attributes, urlPath.Str(), "Uri")
 	}
 
-	if method, methodPresent := GetHttpMethod(attributes); methodPresent {
+	if method, methodPresent := GetHTTPMethod(attributes); methodPresent {
 		return fmt.Sprintf("WebTransaction/http.method/%s", method), WebTransactionType
 	}
 	return "", NullTransactionType
 }
 
-func GetHttpMethod(attributes pcommon.Map) (string, bool) {
+func GetHTTPMethod(attributes pcommon.Map) (string, bool) {
 	method, _ := GetFirst(attributes, []string{"http.request.method", "http.method"})
 	if method.Type() == pcommon.ValueTypeEmpty {
 		return "", false
@@ -432,7 +432,7 @@ func GetHttpMethod(attributes pcommon.Map) (string, bool) {
 }
 
 func GetWebTransactionMetricName(attributes pcommon.Map, name, nameType string) (string, TransactionType) {
-	if method, methodPresent := GetHttpMethod(attributes); methodPresent {
+	if method, methodPresent := GetHTTPMethod(attributes); methodPresent {
 		return fmt.Sprintf("WebTransaction/%s%s (%s)", nameType, name, method), WebTransactionType
 	}
 	return fmt.Sprintf("WebTransaction/%s%s", nameType, name), WebTransactionType

--- a/connector/apmconnector/transaction_test.go
+++ b/connector/apmconnector/transaction_test.go
@@ -36,9 +36,10 @@ func TestGetTransactionMetricNameRoute(t *testing.T) {
 	span := ptrace.NewSpan()
 	span.SetKind(ptrace.SpanKindServer)
 	span.Attributes().PutStr("http.route", "/users")
+	span.Attributes().PutStr("http.method", "GET")
 
 	name, txType := GetTransactionMetricName(span)
-	assert.Equal(t, "WebTransaction/http.route/users", name)
+	assert.Equal(t, "WebTransaction/http.route/users (GET)", name)
 	assert.Equal(t, WebTransactionType, txType)
 }
 
@@ -56,9 +57,10 @@ func TestGetTransactionMetricNameHttpTarget(t *testing.T) {
 	span := ptrace.NewSpan()
 	span.SetKind(ptrace.SpanKindServer)
 	span.Attributes().PutStr("http.target", "/owners/5")
+	span.Attributes().PutStr("http.request.method", "GET")
 
 	name, txType := GetTransactionMetricName(span)
-	assert.Equal(t, "WebTransaction/Uri/owners/5", name)
+	assert.Equal(t, "WebTransaction/Uri/owners/5 (GET)", name)
 	assert.Equal(t, WebTransactionType, txType)
 }
 

--- a/connector/apmconnector/transaction_test.go
+++ b/connector/apmconnector/transaction_test.go
@@ -170,7 +170,7 @@ func TestGetTransactionMetricNameProducer(t *testing.T) {
 	span.Attributes().PutStr("messaging.destination.name", "orders")
 	span.Attributes().PutStr("messaging.operation", "publish")
 
-	name, txType := GetTransactionMetricName(span)
-	assert.Equal(t, "OtherTransaction/Producer/kafka/orders/publish", name)
-	assert.Equal(t, OtherTransactionType, txType)
+	// we don't name transactions with producer spans
+	_, txType := GetTransactionMetricName(span)
+	assert.Equal(t, NullTransactionType, txType)
 }


### PR DESCRIPTION
Refactor the `GetTransactionMetricName` method so that we can use it with metrics.